### PR TITLE
fix discriminator's save file name

### DIFF
--- a/cgan.py
+++ b/cgan.py
@@ -222,7 +222,7 @@ for epoch in range(opt.epoch):
 	
 	# checkpoints 
 	torch.save(generator.state_dict(), '%s/generator_epoch_%d.pth' % (opt.output, epoch))
-	torch.save(discriminator.state_dict(), '%s/generator_epoch_%d.pth' % (opt.output, epoch))
+	torch.save(discriminator.state_dict(), '%s/discriminator_epoch_%d.pth' % (opt.output, epoch))
 
 
 


### PR DESCRIPTION
a little bug: the save file name should be discriminator instead of generator